### PR TITLE
chore(tests): adds test for focus trap

### DIFF
--- a/cypress/integration/recipe-modal.spec.js
+++ b/cypress/integration/recipe-modal.spec.js
@@ -5,10 +5,34 @@ describe('recipe modal component', function() {
     cy.get('.Recipes__card')
       .first()
       .then($el => {
-        cy.wrap($el)
+        $el
           .find(selectors.button)
           .last()
           .click();
       });
+    cy.get(selectors.dialog).should('have.length', 1);
+  });
+  it('gains focus when opened', function() {
+    cy.focused().then($el => {
+      const focused = $el[0];
+      cy.get(selectors.dialog).then($el => {
+        const dialog = $el[0];
+        cy.wrap(dialog.contains(focused)).should('be.true');
+      });
+    });
+  });
+  it('traps focus', function() {
+    cy.get(selectors.dialog).trapsFocus();
+  });
+  it('closes with "Escape" key', function() {
+    const opts = {
+      keyCode: 27,
+      which: 27,
+      code: 'Escape',
+      key: 'Escape',
+      bubbles: true
+    };
+    cy.focused().trigger('keydown', opts);
+    cy.get(selectors.dialog).should('have.length', 0);
   });
 });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -25,7 +25,8 @@ module.exports = (on, config) => {
       main: 'main,[role="main"]',
       link: 'a[href],[role="link"]',
       image: 'img,[role="img"]',
-      button: 'button[type="button"],[role="button"]'
+      button: 'button[type="button"],[role="button"]',
+      dialog: '[role="dialog"]'
     }
   });
 

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -22,7 +22,7 @@ import 'cypress-axe';
 
 const { axe } = JSON.parse(Cypress.env('CONFIG'));
 
-beforeEach(() => {
+before(() => {
   cy.visit('http://localhost:1234');
   // https://github.com/avanslaars/cypress-axe#output
   cy.injectAxe();

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@babel/preset-env": "^7.4.3",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-stage-0": "^7.0.0",
+    "ally.js": "^1.4.1",
     "autoprefixer": "^9.5.1",
     "axe-core": "^3.2.2",
     "babel-eslint": "^10.0.1",


### PR DESCRIPTION
- adds technique for verifying focus trap
- fixes `beforeAll` hook to only be `before` so we can maintain state between `it` blocks
- adds selector for dialog
- adds test for "Escape" to close

TODO: unable to get cypress to maintain focus when closing dialog. Must verify return focus on close manually.