### PR TITLE
chore(tests): adds test for semantic meaning

### DIFF
--- a/cypress/integration/stat.spec.js
+++ b/cypress/integration/stat.spec.js
@@ -1,4 +1,6 @@
 const { selectors } = JSON.parse(Cypress.env('CONFIG'));
+const { _ } = Cypress;
+import data from '../../src/data';
 
 describe('stat component', function() {
   it('has a presentational image', function() {
@@ -9,5 +11,21 @@ describe('stat component', function() {
           .invoke('attr', 'alt')
           .should('equal', '');
       });
+  });
+  it('egg used: displays', function() {
+    // handle parsing ingredients in unit tests
+    cy.findByAccessibleName('eggs used').should('have.length', 1);
+  });
+  it('cook count: displays the correct data', function() {
+    const total = _.sumBy(data, d => d.cookCount);
+    cy.findByAccessibleName(`${total} recipes made`).should('have.length', 1);
+  });
+  it('grease fires: displays the correct data', function() {
+    const total = _.sumBy(data, d => d.greaseFireCount);
+    cy.findByAccessibleName(`${total} grease fires`).should('have.length', 1);
+  });
+  it('yumminess: displays the correct data', function() {
+    const avg = _.meanBy(data, d => d.yumminess);
+    cy.findByAccessibleName(`yumminess ${avg}`).should('have.length', 1);
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -30,6 +30,23 @@ Cypress.Commands.add('accessibleName', { prevSubject: 'element' }, $subject => {
   });
 });
 
+Cypress.Commands.add(
+  'findByAccessibleName',
+  { prevSubject: 'optional' },
+  ($subject, name) => {
+    cy.window({ log: false }).then(win => {
+      const els = $subject
+        ? Array.from($subject)
+        : Array.from(win.document.body.querySelectorAll('*'));
+      win.axe._tree = win.axe.utils.getFlattenedTree(win.document.body);
+      const text = name instanceof RegExp ? name : new RegExp(name, 'im');
+      return els.find(el =>
+        win.axe.commons.text.accessibleText(el).match(text)
+      );
+    });
+  }
+);
+
 // @see https://github.com/cypress-io/cypress/issues/299
 import tabSequence from 'ally.js/query/tabsequence';
 const tab = (el, shiftKey) => {


### PR DESCRIPTION
- adds tests for stat counts from data file
- adds command findByAccessibleName
- example uses Cypress-provided lodash (good comparison to user implementation)