### PR TITLE
Fix cook recipe modal container's local state to update after an edit

### DIFF
--- a/src/containers/RecipeModal.js
+++ b/src/containers/RecipeModal.js
@@ -50,6 +50,27 @@ export default class RecipeModalContainer extends Component {
     };
   }
 
+  // basic string comparison of array contents to make sure local state is up to date
+  static getDerivedStateFromProps(newProps, state) {
+    if (
+      newProps.recipe.ingredients.toString() !== state.ingredients.toString()
+    ) {
+      return {
+        ingredients: newProps.recipe.ingredients
+      };
+    }
+
+    if (
+      newProps.recipe.instructions.toString() !== state.instructions.toString()
+    ) {
+      return {
+        instructions: newProps.recipe.instructions
+      };
+    }
+
+    return null;
+  }
+
   submitSuccess = () => {
     const { edit, updateRecipe, onClose, recipe } = this.props;
     const resetErrors = { errors: defaultErrors };


### PR DESCRIPTION
Issue: A recipe's ingredients or instructions in the cook recipe modal do not reflect new edits when viewing it after saving edits. It only updates the cook recipe modal's local state after opening and closing it and the new changes will appear.

Fix: Use the getDerivedStateFromProps lifecycle method to do a simple array toString string comparison of props with local state values. 